### PR TITLE
email: Changed stray SMTP_SERVER to server

### DIFF
--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -143,7 +143,7 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
     else:
         smtp = _smtplib.SMTP()
     try:
-        smtp.connect(SMTP_SERVER)
+        smtp.connect(server)
     except KeyboardInterrupt:
         raise
     except Exception as e:


### PR DESCRIPTION
There was a stray SMTP_SERVER left over from config.py from the v2.71 era. Sending by SMTP would error out. 

I greped the code and did not find any more leftovers from that config.py (except for comments).

Commit message:

This fixes the error below that occurred upon sending a message by SMTP.

NameError: global name 'SMTP_SERVER' is not defined.

Signed-off-by: George Saunders georgesaunders@gmail.com
