### PR TITLE
Accept feedparser encoding override

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -404,6 +404,12 @@ class Feed (object):
         elif isinstance(exc, _sax.SAXParseException):
             _LOG.error('sax parsing error: {}: {}'.format(exc, self))
             warned = True
+        elif (parsed.bozo and
+              isinstance(exc, _feedparser.CharacterEncodingOverride)):
+            # The feed encoding was incorrectly declared, but the feed parser
+            # was able to automatically determine an encoding.  We don't emit
+            # a warning for this case.
+            pass
         elif parsed.bozo or exc:
             if exc is None:
                 exc = "can't process"


### PR DESCRIPTION
When I run `r2e run`, I get the following error message:

```
processing error: document declared as us-ascii, but parsed as iso-8859-1: undeadly (http://undeadly.org/cgi?action=rss -> jlmuir@imca-cat.org)
```

This is because the server specifies a content type of `text/xml` without an encoding for the [OpenBSD Journal feed](http://undeadly.org/cgi?action=rss), and, according to [feedparser: Introduction to Character Encoding](http://pythonhosted.org/feedparser/character-encoding.html#introduction-to-character-encoding), this will result in an encoding of US-ASCII.  This is sad because the encoding is specified in the XML declaration of the served RSS (in this case, ISO-8859-1); it's just that, according to the RFC, it must be ignored in this case.

Fortunately, the feedparser library does attempt to automatically determine an encoding.  (See [feedparser: Handling Incorrectly-Declared Encodings](http://pythonhosted.org/feedparser/character-encoding.html#handling-incorrectly-declared-encodings).)  In this case, it checks the encoding specified in the XML declaration, and is able to correctly determine that the encoding is ISO-8859-1.  It leaves the `bozo` bit set, and it sets `bozo_exception` to `feedparser.CharacterEncodingOverride`.  This pull request changes rss2email to not emit an error message for this case where the feed encoding is incorrectly declared but the feedparser library is able to automatically determine an encoding.
