### PR TITLE
Force SSLv3 on smtplib.starttls() on Python 3.4

### DIFF
--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -191,6 +191,7 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('smtp-password', 'password'),  # password for SMTP AUTH
         ('smtp-server', 'smtp.yourisp.net:25'),
         ('smtp-ssl', str(False)),       # Connect to the SMTP server using SSL
+        ('smtp-ssl-protocol', 'SSLv3'), # TLS/SSL version to use on STARTTLS when not using 'smtp-ssl'
         # IMAP configuration
         ('imap-auth', str(False)),      # set to True to use IMAP auth.
         ('imap-username', 'username'),  # username for IMAP authentication

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -34,6 +34,7 @@ from email.utils import parseaddr as _parseaddr
 import imaplib as _imaplib
 import io as _io
 import smtplib as _smtplib
+import ssl as _ssl
 import subprocess as _subprocess
 import sys as _sys
 import time as _time
@@ -158,7 +159,13 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
         password = config.get(section, 'smtp-password')
         try:
             if not ssl:
-                smtp.starttls()
+                protocol_name = config.get(section, 'smtp-ssl-protocol')
+                protocol = getattr(_ssl, 'PROTOCOL_{}'.format(protocol_name))
+                try:
+                    smtp.starttls(context=_ssl.SSLContext(protocol=protocol))
+                except TypeError:
+                    # Python 3.2 or earlier
+                    smtp.starttls()
             smtp.login(username, password)
         except KeyboardInterrupt:
             raise


### PR DESCRIPTION
I was getting this error on Python 3.4:

``` python
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/rss2email/email.py", line 161, in smtp_send
    smtp.starttls()
  File "/usr/lib/python3.4/smtplib.py", line 688, in starttls
    server_hostname=server_hostname)
  File "/usr/lib/python3.4/ssl.py", line 364, in wrap_socket
    _context=self)
  File "/usr/lib/python3.4/ssl.py", line 578, in __init__
    self.do_handshake()
  File "/usr/lib/python3.4/ssl.py", line 805, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: TLSV1_ALERT_DECODE_ERROR] tlsv1 alert decode error (_ssl.c:598)
```
