### PR TITLE
Log a warning when Content-Type is not correct

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -423,6 +423,9 @@ class Feed (object):
             _LOG.warning(
                 'incorrectly declared encoding: {}: {}'.format(exc, self))
             warned = True
+        elif (parsed.bozo and isinstance(exc, _feedparser.NonXMLContentType)):
+            _LOG.warning('non XML Content-Type: {}: {}'.format(exc, self))
+            warned = True
         elif parsed.bozo or exc:
             if exc is None:
                 exc = "can't process"


### PR DESCRIPTION
When a feed is served with a wrong Content-Type, log a warning and not an error.
This prevents a "processing error" message from being displayed at the default
log level, which is confusing for a innocuous "error" like this.

See https://bugs.debian.org/760963.

Signed-off-by: Etienne Millon me@emillon.org
