### PR TITLE
pass BODY_WIDTH as 3rd argument to html2text()

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -441,7 +441,7 @@ class Feed (object):
     def _html2text(self, html, baseurl='', default=None):
         self.config.setup_html2text(section=self.section)
         try:
-            return _html2text.html2text(html=html, baseurl=baseurl)
+            return _html2text.html2text(html=html, baseurl=baseurl, bodywidth=_html2text.BODY_WIDTH)
         except _html_parser.HTMLParseError as e:
             if default is not None:
                 return default


### PR DESCRIPTION
setting BODY_WIDTH in config.py alone doesn't work anymore since
html2text has gone through some refactoring and probably broke backwards
compability.

now we need to pass BODY_WIDTH as 3rd argument to the html2text
initializer.

i think these are the html2text commits that let to this incompability:

https://github.com/Alir3z4/html2text/commit/1ba191f11d9e0f01e9a271320b8efdaaa271d199
https://github.com/Alir3z4/html2text/commit/192ca940f8f65b4489d46ae523e9689fd1ca0366

without this fix, changing body-width (to 0 for example) in
rss2email.cfg has no effect.

Signed-off-by: Sebastian Volland <contact@sebastian-volland.de>
