### PR TITLE
Use TLSv1 instead of SSLv3

### DIFF
--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -193,7 +193,7 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('smtp-password', 'password'),  # password for SMTP AUTH
         ('smtp-server', 'smtp.yourisp.net:25'),
         ('smtp-ssl', str(False)),       # Connect to the SMTP server using SSL
-        ('smtp-ssl-protocol', 'SSLv3'), # TLS/SSL version to use on STARTTLS when not using 'smtp-ssl'
+        ('smtp-ssl-protocol', 'TLSv1'), # TLS/SSL version to use on STARTTLS when not using 'smtp-ssl'
         # IMAP configuration
         ('imap-auth', str(False)),      # set to True to use IMAP auth.
         ('imap-username', 'username'),  # username for IMAP authentication

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -161,6 +161,9 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
         try:
             if not ssl:
                 protocol_name = config.get(section, 'smtp-ssl-protocol')
+                if protocol_name == 'SSLv3':
+                    _LOG.warning('SSLv3 is not available, defaulting to TLSv1.')
+                    protocol_name = 'TLSv1'
                 protocol = getattr(_ssl, 'PROTOCOL_{}'.format(protocol_name))
                 try:
                     smtp.starttls(context=_ssl.SSLContext(protocol=protocol))


### PR DESCRIPTION
As reported in https://bugs.debian.org/781315, SSLv3 is now disabled in Python3.
It is thus necessary to perform the following changes:
- modify the default configuration value
- replace the existing uses of SSLv3 by TLSv1 (issuing a warning)
