### PR TITLE
fix tls bug in python 3.4+

### DIFF
--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -145,12 +145,11 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
     server = config.get(section, 'smtp-server')
     _LOG.debug('sending message to {} via {}'.format(recipient, server))
     ssl = config.getboolean(section, 'smtp-ssl')
-    if ssl:
-        smtp = _smtplib.SMTP_SSL()
-    else:
-        smtp = _smtplib.SMTP()
     try:
-        smtp.connect(server)
+        if ssl:
+            smtp = _smtplib.SMTP_SSL(host=server)
+        else:
+            smtp = _smtplib.SMTP(host=server)
     except KeyboardInterrupt:
         raise
     except Exception as e:


### PR DESCRIPTION
Fix tls bug in case of python 3.4+.
See: http://stackoverflow.com/questions/23616803/smtplib-smtp-starttls-fails-with-tlsv1-alert-decode-error

Note: it is possible that the same fix should be applied to the SSL case, but I don't have such email server to test it.