### PR TITLE
r2e new: do not overwrite existing config

### DIFF
--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -17,6 +17,7 @@
 """rss2email commands
 """
 
+import os as _os
 import re as _re
 import sys as _sys
 import xml.dom.minidom as _minidom
@@ -31,6 +32,8 @@ def new(feeds, args):
     if args.email:
         _LOG.info('set the default target email to {}'.format(args.email))
         feeds.config['DEFAULT']['to'] = args.email
+    if _os.path.exists(feeds.configfiles[-1]):
+        raise _error.ConfigAlreadyExistsError(feeds=feeds)
     feeds.save()
 
 def email(feeds, args):

--- a/rss2email/error.py
+++ b/rss2email/error.py
@@ -258,3 +258,9 @@ class OPMLReadError (RSS2EmailError):
     def __init__(self, **kwargs):
         message = 'error reading OPML'
         super(OPMLReadError, self).__init__(message=message, **kwargs)
+
+
+class ConfigAlreadyExistsError (FeedsError):
+    def __init__(self, feeds=None):
+        message = 'configuration file already exists'
+        super().__init__(feeds=feeds, message=message)


### PR DESCRIPTION
If a configuration file already exists, "r2e new" will overwrite it.
This was reported in the following bug report:

https://bugs.debian.org/805224

This adds a check when running "r2e new" that will exit if the configuration
file already exists.

Thanks!
