### PR TITLE
Fix SMTP security issues

### DIFF
--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -193,7 +193,7 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('smtp-password', 'password'),  # password for SMTP AUTH
         ('smtp-server', 'smtp.example.net:25'),
         ('smtp-ssl', str(False)),       # Connect to the SMTP server using SSL
-        ('smtp-ssl-protocol', 'SSLv3'), # TLS/SSL version to use on STARTTLS when not using 'smtp-ssl'
+        ('smtp-ssl-protocol', 'SSLv23'), # TLS/SSL version to use (SSLv23 selects the highest protocol version that both the client and server support. Despite the name, this option can select "TLS" protocols as well as "SSL".)
         # IMAP configuration
         ('imap-auth', str(False)),      # set to True to use IMAP auth.
         ('imap-username', 'username'),  # username for IMAP authentication

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -191,7 +191,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('smtp-auth', str(False)),      # set to True to use SMTP AUTH
         ('smtp-username', 'username'),  # username for SMTP AUTH
         ('smtp-password', 'password'),  # password for SMTP AUTH
-        ('smtp-server', 'smtp.example.net:25'),
+        ('smtp-server', 'smtp.example.net'),
+        ('smtp-port', '465'),
         ('smtp-ssl', str(False)),       # Connect to the SMTP server using SSL
         # IMAP configuration
         ('imap-auth', str(False)),      # set to True to use IMAP auth.

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -193,7 +193,6 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('smtp-password', 'password'),  # password for SMTP AUTH
         ('smtp-server', 'smtp.example.net:25'),
         ('smtp-ssl', str(False)),       # Connect to the SMTP server using SSL
-        ('smtp-ssl-protocol', 'SSLv23'), # TLS/SSL version to use (SSLv23 selects the highest protocol version that both the client and server support. Despite the name, this option can select "TLS" protocols as well as "SSL".)
         # IMAP configuration
         ('imap-auth', str(False)),      # set to True to use IMAP auth.
         ('imap-username', 'username'),  # username for IMAP authentication

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -145,16 +145,15 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
     server = config.get(section, 'smtp-server')
     _LOG.debug('sending message to {} via {}'.format(recipient, server))
     ssl = config.getboolean(section, 'smtp-ssl')
-    smtp-auth = config.getboolean(section, 'smtp-auth')
+    smtp_auth = config.getboolean(section, 'smtp-auth')
     try:
-        if ssl or smtp-auth:
+        if ssl or smtp_auth:
                 try:
                     context = _ssl.create_default_context()
                 except AttributeError: # Python 3.3 or earlier
                     context = _ssl.SSLContext(protocol=_ssl.PROTOCOL_SSLv23)
                     context.verify_mode = _ssl.CERT_REQUIRED
                     context.set_default_verify_paths()
-
         if ssl:
             try:
                 smtp = _smtplib.SMTP_SSL(host=server, context=context)
@@ -166,7 +165,7 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
         raise
     except Exception as e:
         raise _error.SMTPConnectionError(server=server) from e
-    if smtp-auth:
+    if smtp_auth:
         username = config.get(section, 'smtp-username')
         password = config.get(section, 'smtp-password')
         try:

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -143,6 +143,8 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
     if config is None:
         config = _config.CONFIG
     server = config.get(section, 'smtp-server')
+    port = config.getint(section, 'smtp-port')
+
     _LOG.debug('sending message to {} via {}'.format(recipient, server))
     ssl = config.getboolean(section, 'smtp-ssl')
     smtp_auth = config.getboolean(section, 'smtp-auth')
@@ -156,11 +158,11 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
                     context.set_default_verify_paths()
         if ssl:
             try:
-                smtp = _smtplib.SMTP_SSL(host=server, context=context)
+                smtp = _smtplib.SMTP_SSL(host=server, port=port, context=context)
             except TypeError: # Python 3.2 or earlier
-                smtp = _smtplib.SMTP_SSL(host=server) 
+                smtp = _smtplib.SMTP_SSL(host=server, port=port) 
         else:
-            smtp = _smtplib.SMTP(host=server)
+            smtp = _smtplib.SMTP(host=server, port=port)
     except KeyboardInterrupt:
         raise
     except Exception as e:

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -148,17 +148,6 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
     smtp-auth = config.getboolean(section, 'smtp-auth')
     try:
         if ssl or smtp-auth:
-            protocol_name = config.get(section, 'smtp-ssl-protocol') 
-            if protocol_name:
-                protocol = getattr(_ssl, 'PROTOCOL_{}'.format(protocol_name))
-                context = _ssl.SSLContext(protocol=protocol)
-                context.verify_mode = ssl.CERT_REQUIRED
-                try:
-                    context.check_hostname = True
-                    context.load_default_certs()
-                except AttributeError: #Python 3.3 or earlier
-                    context.set_default_verify_paths()
-            else:
                 try:
                     context = ssl.create_default_context()
                 except AttributeError: # Python 3.3 or earlier

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -154,7 +154,10 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
                     context = _ssl.SSLContext(protocol=_ssl.PROTOCOL_SSLv23)
 
         if ssl:
-            smtp = _smtplib.SMTP_SSL(host=server, context=context)
+            try:
+                smtp = _smtplib.SMTP_SSL(host=server, context=context)
+            except TypeError: # Python 3.2 or earlier
+                smtp = _smtplib.SMTP_SSL(host=server) 
         else:
             smtp = _smtplib.SMTP(host=server)
     except KeyboardInterrupt:

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -149,9 +149,11 @@ def smtp_send(sender, recipient, message, config=None, section='DEFAULT'):
     try:
         if ssl or smtp-auth:
                 try:
-                    context = ssl.create_default_context()
+                    context = _ssl.create_default_context()
                 except AttributeError: # Python 3.3 or earlier
                     context = _ssl.SSLContext(protocol=_ssl.PROTOCOL_SSLv23)
+                    context.verify_mode = _ssl.CERT_REQUIRED
+                    context.set_default_verify_paths()
 
         if ssl:
             try:


### PR DESCRIPTION
Before this fix, SSL certificates were not verified and the hostname was not matched to the ssl certificate. (Even if the certificates were verified, an attacker could use a free ssl certificate for any domain and it would be accepted.)

Citing Python SSL security considerations (https://docs.python.org/3/library/ssl.html#ssl-security):
"For client use, if you don’t have any special requirements for your security policy, it is highly recommended that you use the create_default_context() function to create your SSL context. It will load the system’s trusted CA certificates, enable certificate validation and hostname checking, and try to choose reasonably secure protocol and cipher settings."

This fix is backwards compatible with Python 3.2.
These changes overlap with the changes already suggested by wking in this PR: https://github.com/wking/rss2email/pull/59#issuecomment-164196261
