### PR TITLE
Remove misplaced flags from re.sub() call

### DIFF
--- a/rss2email/post_process/redirect.py
+++ b/rss2email/post_process/redirect.py
@@ -62,7 +62,7 @@ def process(feed, parsed, entry, guid, message):
             LOG.warning('could not follow redirect for {}: {}'.format(
                 linke, e))
             continue
-        content = re.sub(re.escape(link), direct_link, content, re.MULTILINE)
+        content = re.sub(re.escape(link), direct_link, content)
 
     # clear CTE and set message. It can be important to clear the CTE
     # before setting the payload, since the payload is only re-encoded


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.
Moreover, `re.MULTILINE` affects only semantics of `^` and `$`, so it wouldn't have any effect on this regular expression.

Found using [pydiatra](https://github.com/jwilk/pydiatra).