### PR TITLE
README: don't recommend removed use-smtp setting

### DIFF
--- a/README
+++ b/README
@@ -173,7 +173,7 @@ your outoing email server's details::
 
   [DEFAULT]
   ...
-  use-smtp = True
+  email-protocol = smtp
   smtp-server = smtp.example.net:587
   smtp-auth = False
   ...


### PR DESCRIPTION
The CHANGELOG mentions this was replaced in 2013, update README
accordingly.